### PR TITLE
Explicitly pass values kwarg to tf.name_scope

### DIFF
--- a/tfmpl/samples/sgd.py
+++ b/tfmpl/samples/sgd.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
 
         def beale(x, y):
             '''Beale surface for optimization tests.'''
-            with tf.name_scope('beale', [x, y]):
+            with tf.name_scope('beale', values=[x, y]):
                 return (1.5 - x + x*y)**2 + (2.25 - x + x*y**2)**2 + (2.625 - x + x*y**3)**2
 
         # List of optimizers to compare


### PR DESCRIPTION
Explicitly pass values kwarg to tf.name_scope as it is currently being treated as the default_name kwarg instead. This causes an exception to be thrown in eager mode.